### PR TITLE
sh_malloc and sh_free signature change.

### DIFF
--- a/crypto/mem_sec.c
+++ b/crypto/mem_sec.c
@@ -538,7 +538,7 @@ static void *sh_malloc(size_t size)
 static void sh_free(void *ptr)
 {
     size_t list;
-    char *buddy;
+    void *buddy;
 
     if (ptr == NULL)
         return;

--- a/crypto/mem_sec.c
+++ b/crypto/mem_sec.c
@@ -52,8 +52,8 @@ static CRYPTO_RWLOCK *sec_malloc_lock = NULL;
  * These are the functions that must be implemented by a secure heap (sh).
  */
 static int sh_init(size_t size, int minsize);
-static char *sh_malloc(size_t size);
-static void sh_free(char *ptr);
+static void *sh_malloc(size_t size);
+static void sh_free(void *ptr);
 static void sh_done(void);
 static size_t sh_actual_size(char *ptr);
 static int sh_allocated(const char *ptr);
@@ -476,7 +476,7 @@ static char *sh_find_my_buddy(char *ptr, int list)
     return chunk;
 }
 
-static char *sh_malloc(size_t size)
+static void *sh_malloc(size_t size)
 {
     ossl_ssize_t list, slist;
     size_t i;
@@ -535,7 +535,7 @@ static char *sh_malloc(size_t size)
     return chunk;
 }
 
-static void sh_free(char *ptr)
+static void sh_free(void *ptr)
 {
     size_t list;
     char *buddy;


### PR DESCRIPTION
##### Description of change
sh_malloc and sh_free act as masks of malloc and free as specified by ISO C (POSIX follows this standard). For the sake of consistency, it seems wise to make sure that the signature of sh_malloc matches malloc's signature and to make sure that the signature of sh_free matches the signature of free.

This small code change fixes this. It compiles under `config -d --strict-warnings` without any issues. I ran the included testsuite (`make test`), and it finished without problems.